### PR TITLE
Add typescript types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,0 +1,28 @@
+
+import { DateSchema, Extension, Root } from 'joi';
+
+declare module 'joi' {
+
+    interface DateSchema {
+
+        /**
+         * Specifies the allowed date format.
+         * 
+         * @param format - string or array of strings that follow the moment.js format.
+         */
+        format(format: string | string[]): this;
+
+        /**
+         * Dates will be parsed as UTC instead of using the machine's local timezone.
+         */
+        utc(): this;
+    }
+}
+
+interface DateExtension extends Extension {
+    type: 'date';
+    base: DateSchema;
+}
+
+declare const JoiDateFactory: (joi: Root) => DateExtension;
+export default JoiDateFactory;

--- a/lib/index.js
+++ b/lib/index.js
@@ -59,3 +59,7 @@ module.exports = (joi) => {
         }
     };
 };
+
+// Default export for TypeScript module interop
+
+module.exports.default = module.exports;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "2.0.1",
   "repository": "git://github.com/sideway/joi-date",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "keywords": [
     "schema",
     "validation",
@@ -17,11 +18,12 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/joi": "17.x.x",
-    "@hapi/lab": "24.x.x"
+    "@hapi/lab": "24.x.x",
+    "joi": "^17.2.0",
+    "typescript": "4.0.x"
   },
   "scripts": {
-    "test": "lab -t 100 -a @hapi/code -L",
+    "test": "lab -t 100 -a @hapi/code -L -Y",
     "test-cov-html": "lab -r html -o coverage.html -a @hapi/code"
   },
   "license": "BSD-3-Clause"

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Code = require('@hapi/code');
-const Joi = require('@hapi/joi');
+const Joi = require('joi');
 const JoiDate = require('..');
 const Lab = require('@hapi/lab');
 const Moment = require('moment');

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,16 @@
+
+import * as BaseJoi from 'joi';
+import JoiDate from '..';
+import * as Lab from '@hapi/lab';
+
+
+const { expect } = Lab.types;
+
+const Joi = BaseJoi.extend(JoiDate) as BaseJoi.Root;
+
+Joi.date().format('YYYY-MM-DD HH:mm');
+Joi.date().format(['YYYY/MM/DD', 'DD-MM-YYYY']);
+expect.error(Joi.date().format());
+
+Joi.date().utc();
+expect.error(Joi.date().utc(true));


### PR DESCRIPTION
Closes #26.

Note that I had to add a `default` export to the regular code to support the import syntax. Otherwise, users would have to use the `import JoiDate = require('joi/date')` syntax.